### PR TITLE
add a library which converts an xyz file to z-matrix format

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,9 +26,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
+          conda install $(grep -v numgrid requirements.txt)
           # numgrid isn't on conda-forge, and latest version is not available on mac/arm
           if [ $(uname) = Linux -o $(uname) = Darwin ]; then pip install numgrid==1.1.2 ; fi
-          conda install $(grep -v numgrid requirements.txt)
           pip install flake8 pytest
       - name: Lint with flake8
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
 
     defaults:
       run:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     defaults:
       run:

--- a/pymolpro/__init__.py
+++ b/pymolpro/__init__.py
@@ -6,9 +6,10 @@ from pymolpro.orbital import Orbital
 from pymolpro.tuple import Tuple, Single, Pair
 import pymolpro.database
 from . import _version
-from . import convert_from_xyz_to_molprozmat
+# from . import convert_from_xyz_to_molprozmat
+from pymolpro.convert_from_xyz_to_molprozmat import xyz_to_zmat
 
-__all__ = ['Project', 'Orbital', 'Pair', 'Single', 'Tuple', 'no_errors', 'element_to_dict', 'Database']
+__all__ = ['Project', 'Orbital', 'Pair', 'Single', 'Tuple', 'no_errors', 'element_to_dict', 'Database', 'xyz_to_zmat']
 
 Settings.set('project_default_suffix', 'molpro')
 pysjef.project_factory.PROJECT_FACTORY["molpro"] = project.Project

--- a/pymolpro/__init__.py
+++ b/pymolpro/__init__.py
@@ -7,7 +7,7 @@ from pymolpro.tuple import Tuple, Single, Pair
 import pymolpro.database
 from . import _version
 # from . import convert_from_xyz_to_molprozmat
-from pymolpro.convert_from_xyz_to_molprozmat import xyz_to_zmat
+from pymolpro.geometry import xyz_to_zmat
 
 __all__ = ['Project', 'Orbital', 'Pair', 'Single', 'Tuple', 'no_errors', 'element_to_dict', 'Database', 'xyz_to_zmat']
 

--- a/pymolpro/__init__.py
+++ b/pymolpro/__init__.py
@@ -6,6 +6,7 @@ from pymolpro.orbital import Orbital
 from pymolpro.tuple import Tuple, Single, Pair
 import pymolpro.database
 from . import _version
+from . import convert_from_xyz_to_molprozmat
 
 __all__ = ['Project', 'Orbital', 'Pair', 'Single', 'Tuple', 'no_errors', 'element_to_dict', 'Database']
 

--- a/pymolpro/convert_from_xyz_to_molprozmat.py
+++ b/pymolpro/convert_from_xyz_to_molprozmat.py
@@ -1,0 +1,46 @@
+import string
+import re
+import chemcoord
+
+def convert_xyz_to_molprozmat(xyzinput):
+    chemcoordzmat = convert_xyz_to_chemcoordzmat(xyzinput)
+    print ('z-matrix from chemcoord:')
+    print(chemcoordzmat)
+    molprozmat = convert_chemcoordzmat_to_molprozmat(chemcoordzmat)
+    print('\nz-matrix for Molpro:')
+    print(molprozmat)
+    return molprozmat
+
+def convert_xyz_to_chemcoordzmat(xyzinput):
+    xyzfile = chemcoord.Cartesian.read_xyz(xyzinput, start_index = 1)
+    chemcoordzmat = xyzfile.get_zmat()
+    return chemcoordzmat
+
+def convert_chemcoordzmat_to_molprozmat(chemcoordzmat):
+    f = str(chemcoordzmat)
+    n = 0
+    for x in f.splitlines():
+        n = n +1
+        if (n == 1):
+            continue
+        atom1 = x.split()[1] + x.split()[0]
+        if (n == 2):
+            atomdict = {x.split()[0] : x.split()[1]}
+            zmatrix = atomdict.get(x.split()[0]) + x.split()[0]+'\n'
+        atomdict[x.split()[0]] = x.split()[1]
+        if (n > 2):
+            atom2 = atomdict.get(x.split()[2]) + (x.split()[2])
+        if (n == 3):
+            line2 = atom1 + " " + atom2 + " " + x.split()[3]
+            zmatrix = zmatrix + line2+'\n'
+        if (n > 3):
+            atom3 = str(atomdict.get(x.split()[4])) + x.split()[4]
+        if (n == 4):
+            line3 = atom1 + " " + atom2 + " " + x.split()[3] + " " + atom3 + " " + x.split()[5]
+            zmatrix = zmatrix + line3+'\n'
+        atom4 = str(atomdict.get(x.split()[6])) + x.split()[6]
+        if (n > 4):
+            line4 = atom1 + " " + atom2 + " " + x.split()[3] + " " + atom3 + " " + x.split()[5] + " " + atom4 + " " + x.split()[7]
+            zmatrix = zmatrix + line4+'\n'
+    return zmatrix
+

--- a/pymolpro/convert_from_xyz_to_molprozmat.py
+++ b/pymolpro/convert_from_xyz_to_molprozmat.py
@@ -1,5 +1,6 @@
 import string
 import re
+import os
 
 def xyz_to_zmat(xyz:str, algorithm='chemcoord'):
     """
@@ -37,7 +38,14 @@ def convert_xyz_to_chemcoordzmat(xyzinput):
     :return: chemcoordzmat , no check for errors
     """
     import chemcoord
-    xyzfile = chemcoord.Cartesian.read_xyz(xyzinput, start_index = 1)
+    if os.access(xyzinput, os.R_OK):
+        xyzfile = chemcoord.Cartesian.read_xyz(xyzinput, start_index = 1)
+    else:
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix='.xyz') as f:
+            f.write(xyzinput.encode('utf-8'))
+            f.flush()
+            xyzfile = chemcoord.Cartesian.read_xyz(f.name, start_index = 1)
     chemcoordzmat = xyzfile.get_zmat()
     return chemcoordzmat
 

--- a/pymolpro/convert_from_xyz_to_molprozmat.py
+++ b/pymolpro/convert_from_xyz_to_molprozmat.py
@@ -1,9 +1,29 @@
 import string
 import re
-import chemcoord
 
-def convert_xyz_to_molprozmat(xyzinput):
-    chemcoordzmat = convert_xyz_to_chemcoordzmat(xyzinput)
+def xyz_to_zmat(xyz:str, algorithm='chemcoord'):
+    """
+    Converts from xyz to z-matrix coordinates.
+    :param xyz: xyz-file
+    :param algorithm: algorithm to choose, Default is the chemcoord-algorithm
+    :return: zmat or -1 in case of unknown algorithm,
+    no check for errors however in functions called
+    """
+
+    if (algorithm == 'chemcoord'):
+        zmat = xyz_via_chemcoord_to_molprozmat(xyz)
+    else:
+        zmat = -1
+    return zmat
+
+def xyz_via_chemcoord_to_molprozmat(xyz):
+    """
+    Converts from xyz to z-matrix coordinates, using chemcoord-algorithm
+    :param xyz: xyz-file
+    :return: molprozmat , no check for errors
+    """
+    import chemcoord
+    chemcoordzmat = convert_xyz_to_chemcoordzmat(xyz)
     print ('z-matrix from chemcoord:')
     print(chemcoordzmat)
     molprozmat = convert_chemcoordzmat_to_molprozmat(chemcoordzmat)
@@ -12,11 +32,26 @@ def convert_xyz_to_molprozmat(xyzinput):
     return molprozmat
 
 def convert_xyz_to_chemcoordzmat(xyzinput):
+    """
+    Converts from xyz to z-matrix coordinates in chemcoord-format
+    :param xyz: xyz-file
+    :return: chemcoordzmat , no check for errors
+    """
+    import chemcoord
     xyzfile = chemcoord.Cartesian.read_xyz(xyzinput, start_index = 1)
     chemcoordzmat = xyzfile.get_zmat()
     return chemcoordzmat
 
 def convert_chemcoordzmat_to_molprozmat(chemcoordzmat):
+    """
+    Converts z-matrix from chemcoord format to molpro format
+    :param chemcoordzmat: z-matrix in chemcoord format
+    :return: zmatrix , no check for errors
+    assumption is that axes e_z and e_x
+    are only used for the first two atoms (this may not be the case if
+    the ininital z-matrix form chemcoord is further transformed,
+    and dummies appear in the chemcoord z-matrix)
+    """
     f = str(chemcoordzmat)
     n = 0
     for x in f.splitlines():
@@ -44,3 +79,17 @@ def convert_chemcoordzmat_to_molprozmat(chemcoordzmat):
             zmatrix = zmatrix + line4+'\n'
     return zmatrix
 
+if (__name__ == "__main__"):
+    """
+    when called from the command line
+    :param xyz: xyz-file
+    :param algorithm: algorithm to choose, Default is the chemcoord-algorithm
+    :example: python pymolpro/convert_from_xyz_to_molprozmat.py ../../tests-fuer-xyz-to-zmat-conversion/glycine.xyz
+    """
+    import sys
+    import os
+    if len(sys.argv) >1:
+        if (os.path.isfile(sys.argv[1])):
+            xyz_to_zmat(sys.argv[1], algorithm='chemcoord')
+    else:
+        pass

--- a/pymolpro/convert_from_xyz_to_molprozmat.py
+++ b/pymolpro/convert_from_xyz_to_molprozmat.py
@@ -22,7 +22,6 @@ def xyz_via_chemcoord_to_molprozmat(xyz):
     :param xyz: xyz-file
     :return: molprozmat , no check for errors
     """
-    import chemcoord
     chemcoordzmat = convert_xyz_to_chemcoordzmat(xyz)
     print ('z-matrix from chemcoord:')
     print(chemcoordzmat)

--- a/pymolpro/geometry.py
+++ b/pymolpro/geometry.py
@@ -5,35 +5,36 @@ import os
 def xyz_to_zmat(xyz:str, algorithm='chemcoord'):
     """
     Converts from xyz to z-matrix coordinates.
+
     :param xyz: xyz-file
-    :param algorithm: algorithm to choose, Default is the chemcoord-algorithm
-    :return: zmat or -1 in case of unknown algorithm,
-    no check for errors however in functions called
+    :param algorithm: algorithm to choose, default is the chemcoord algorithm
+    :return: The Z matrix as a string, or None in case of unknown algorithm,
+    :rtype: str
     """
 
     if (algorithm == 'chemcoord'):
-        zmat = xyz_via_chemcoord_to_molprozmat(xyz)
-    else:
-        zmat = -1
-    return zmat
+        return xyz_via_chemcoord_to_molprozmat(xyz)
+    return None
 
 def xyz_via_chemcoord_to_molprozmat(xyz):
     """
     Converts from xyz to z-matrix coordinates, using chemcoord-algorithm
+
     :param xyz: xyz-file
     :return: molprozmat , no check for errors
     """
     chemcoordzmat = convert_xyz_to_chemcoordzmat(xyz)
-    print ('z-matrix from chemcoord:')
-    print(chemcoordzmat)
+    # print ('z-matrix from chemcoord:')
+    # print(chemcoordzmat)
     molprozmat = convert_chemcoordzmat_to_molprozmat(chemcoordzmat)
-    print('\nz-matrix for Molpro:')
-    print(molprozmat)
+    # print('\nz-matrix for Molpro:')
+    # print(molprozmat)
     return molprozmat
 
 def convert_xyz_to_chemcoordzmat(xyzinput):
     """
     Converts from xyz to z-matrix coordinates in chemcoord-format
+
     :param xyz: xyz-file
     :return: chemcoordzmat , no check for errors
     """
@@ -91,7 +92,7 @@ if (__name__ == "__main__"):
     when called from the command line
     :param xyz: xyz-file
     :param algorithm: algorithm to choose, Default is the chemcoord-algorithm
-    :example: python pymolpro/convert_from_xyz_to_molprozmat.py ../../tests-fuer-xyz-to-zmat-conversion/glycine.xyz
+    :example: python pymolpro/geometry.py ../../tests-fuer-xyz-to-zmat-conversion/glycine.xyz
     """
     import sys
     import os

--- a/pymolpro/geometry.py
+++ b/pymolpro/geometry.py
@@ -90,6 +90,7 @@ def convert_chemcoordzmat_to_molprozmat(chemcoordzmat):
 if (__name__ == "__main__"):
     """
     when called from the command line
+    
     :param xyz: xyz-file
     :param algorithm: algorithm to choose, Default is the chemcoord-algorithm
     :example: python pymolpro/geometry.py ../../tests-fuer-xyz-to-zmat-conversion/glycine.xyz
@@ -97,7 +98,4 @@ if (__name__ == "__main__"):
     import sys
     import os
     if len(sys.argv) >1:
-        if (os.path.isfile(sys.argv[1])):
-            xyz_to_zmat(sys.argv[1], algorithm='chemcoord')
-    else:
-        pass
+        print(xyz_to_zmat(sys.argv[1], algorithm='chemcoord'))

--- a/pymolpro/test_zmat.py
+++ b/pymolpro/test_zmat.py
@@ -1,0 +1,20 @@
+import unittest
+import pymolpro
+
+
+class TestZmat(unittest.TestCase):
+    def test_zmat_string(self):
+        z = pymolpro.xyz_to_zmat('2\ntest\nF 0.0 0.0 0.0\nH 0.0 0.0 1.0')
+        assert z == 'F1\nH2 F1 1.0\n'
+
+    def test_zmat_file(self):
+        import tempfile
+        with tempfile.NamedTemporaryFile(suffix='.xyz') as f:
+            f.write('2\ntest\nF 0.0 0.0 0.0\nH 0.0 0.0 1.0'.encode('utf-8'))
+            f.flush()
+            z = pymolpro.xyz_to_zmat(f.name)
+            assert z == 'F1\nH2 F1 1.0\n'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ sphinx-rtd-theme>=1.0.0
 #numgrid==1.1.2
 pandas
 versioneer
+chemcoord

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest
 regex
 lxml
 scipy>=1.9.3
-numpy
+numpy<2
 sphinx-rtd-theme>=1.0.0
 #numgrid==1.1.2
 pandas


### PR DESCRIPTION
the z-matrix is obtained from chemcoord
TODO: 1) switch for __main__
      2) trap cases if dummy appears in z-matrix (should not, but as a
	 precaution)
      3) add chemcoord to requirements when installing
syntax:
from pymolpro import convert_from_xyz_to_molprozmat convert_from_xyz_to_molprozmat.convert_xyz_to_molprozmat('mymolecule.xyz')