### PR TITLE
Proper detection of Kohn-Sham methods in input specification, to avoid injecting an unneeded Hartree-Fox

### DIFF
--- a/pymolpro/molpro_input.py
+++ b/pymolpro/molpro_input.py
@@ -308,7 +308,7 @@ class InputSpecification(UserDict):
         if not methods:
             self['method'] = self.with_defaults['method']
             return
-        if methods[0].lower() not in ['hf', 'rhf', 'uhf', 'ks', 'rks', 'uks', 'avas']:
+        if methods[0].lower().split(',')[0] not in ['hf', 'rhf', 'uhf', 'ks', 'rks', 'uks', 'avas']:
             self['method'] = ['hf' if methods[0].lower()[0] != 'u' else 'uhf'] + methods
 
     @property


### PR DESCRIPTION
Fixes #152
